### PR TITLE
Fixed "relatedWords" method.

### DIFF
--- a/lib/word.js
+++ b/lib/word.js
@@ -10,7 +10,7 @@ var Word = module.exports = function(api, o) {
   });
 };
 
-['examples', 'definitions', 'frequency', 'topExample', 'related', 'phrases', 'hyphenation', 'pronunciations', 'audio'].forEach(function(method) {
+['examples', 'definitions', 'frequency', 'topExample', 'relatedWords', 'phrases', 'hyphenation', 'pronunciations', 'audio'].forEach(function(method) {
   Word.prototype[method] = function(params, fn) {
     if (typeof params == 'function') {
       fn = params;


### PR DESCRIPTION
"related" was incorrect and did not work, the correct working method is "relatedWords".