### PR TITLE
Fixed "relatedWords" method

### DIFF
--- a/lib/wordnik.js
+++ b/lib/wordnik.js
@@ -30,7 +30,7 @@ Wordnik.prototype.word = function(word, params, fn) {
   });
 };
 
-['examples', 'definitions', 'frequency', 'topExample', 'related', 'phrases', 'hyphenation', 'pronunciations', 'audio'].forEach(function(method) {
+['examples', 'definitions', 'frequency', 'topExample', 'relatedWords', 'phrases', 'hyphenation', 'pronunciations', 'audio'].forEach(function(method) {
   Wordnik.prototype[method] = function(word, params, fn) {
     if (typeof params == 'function') {
       fn = params;


### PR DESCRIPTION
"related" was incorrect and did not work, the correct working method is "relatedWords".